### PR TITLE
Fixed relative path & added predeploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,24 @@ import "./index.css";
 The Babel preset [babel-preset-nano-react-app](https://github.com/adrianmcli/babel-preset-nano-react-app) and a small amount of configuration is used to support the same transforms that Create React App supports.
 
 The Babel configuration lives inside `package.json` and will override an external `.babelrc` file, so if you want to use `.babelrc` remember to delete the `babel` property inside `package.json`.
+
+
+## Deploy to GitHub Pages
+
+You can also deploy your project using GitHub pages.
+First install the gh-pages package:
+
+`npm i -D gh-pages`
+
+With Parcel's --public-url flag, use the following scripts for deployment:
+
+```
+"scripts": {
+		"start": "parcel index.html",
+		"build": "parcel build index.html --public-url '.'",
+		"predeploy": "rm -rf dist && parcel build index.html --public-url '.'",
+		"deploy": "gh-pages -d dist"
+	},
+```
+
+Then follow the normal procedure in GitHub Pages and select the `gh-pages` branch.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Hard to get more minimal than this React app",
   "scripts": {
     "start": "parcel index.html",
-    "build": "parcel build index.html --public-url '.'", 
-    "predeploy": "rm -rf dist && parcel build index.html --public-url '.'"    
+    "build": "parcel build index.html"
   },
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Hard to get more minimal than this React app",
   "scripts": {
     "start": "parcel index.html",
-    "build": "parcel build index.html"
+    "build": "parcel build index.html --public-url '.'", 
+    "predeploy": "rm -rf dist && parcel build index.html --public-url '.'"    
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Fix for the [issue](https://github.com/adrianmcli/nano-react-app/issues/14) with the relative paths when deploying via gh-pages.
Also added the `predeploy` option removing the dist folder before building.