### PR TITLE
Bumped React version to latest. Removed reference to old Babel preset.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,10 @@
         "build": "vite build"
     },
     "dependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
     },
     "devDependencies": {
-        "babel-preset-nano-react-app": "^0.1.0",
-        "vite": "^5.2.6"
-    },
-    "babel": {
-        "presets": [
-            "nano-react-app"
-        ]
+        "vite": "^6.2.0"
     }
 }


### PR DESCRIPTION
Version bump for React. We don't need that babel preset (probably haven't for a while) so I've removed that reference from dev dependencies too.